### PR TITLE
feat(api): finalize screening scoring endpoints for patient and admin

### DIFF
--- a/app/Http/Controllers/ScreeningScoringController.php
+++ b/app/Http/Controllers/ScreeningScoringController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ScreeningScoring;
+use Illuminate\Http\Request;
+
+class ScreeningScoringController extends Controller
+{
+    public function index()
+    {
+        return response()->json([
+            'meta' => ['status' => 'success'],
+            'data' => ScreeningScoring::with('questionSet')->get()
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'type' => 'required|in:HT,DM',
+            'question_set_id' => 'required|exists:question_sets,id',
+        ]);
+
+        $screening = ScreeningScoring::create($request->only([
+            'name',
+            'type',
+            'question_set_id'
+        ]));
+
+        return response()->json([
+            'meta' => [
+                'status' => 'success',
+                'message' => 'Screening scoring created'
+            ],
+            'data' => $screening
+        ], 201);
+    }
+
+    public function show($id)
+    {
+        $screening = ScreeningScoring::with([
+            'questionSet.questions.options'
+        ])->find($id);
+
+        if (!$screening) {
+            return response()->json([
+                'meta' => ['status' => 'error', 'message' => 'Screening scoring not found'],
+            ], 404);
+        }
+
+        return response()->json([
+            'meta' => ['status' => 'success'],
+            'data' => $screening
+        ]);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $screening = ScreeningScoring::find($id);
+
+        if (!$screening) {
+            return response()->json(['message' => 'Not found'], 404);
+        }
+
+        $request->validate([
+            'name' => 'sometimes|string|max:255',
+            'type' => 'sometimes|in:HT,DM',
+            'question_set_id' => 'sometimes|exists:question_sets,id',
+        ]);
+
+        $screening->update($request->only(['name', 'type', 'question_set_id']));
+
+        return response()->json([
+            'meta' => ['status' => 'success', 'message' => 'Screening scoring updated'],
+            'data' => $screening
+        ]);
+    }
+
+    public function destroy($id)
+    {
+        $screening = ScreeningScoring::find($id);
+
+        if (!$screening) {
+            return response()->json(['message' => 'Not found'], 404);
+        }
+
+        $screening->delete();
+
+        return response()->json(['message' => 'Deleted']);
+    }
+}

--- a/app/Http/Controllers/UserAnswerScreeningScoringController.php
+++ b/app/Http/Controllers/UserAnswerScreeningScoringController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use App\Models\Option;
+use App\Models\UserHistoryScreeningScoring;
+use App\Models\UserAnswerScreeningScoring;
+
+class UserAnswerScreeningScoringController extends Controller
+{
+    public function submit(Request $request)
+    {
+        \Log::info('[submit] Incoming Request', $request->all());
+
+        try {
+            $user = \Tymon\JWTAuth\Facades\JWTAuth::parseToken()->authenticate();
+        } catch (\Throwable $e) {
+            \Log::error('[submit] Auth failed', [
+                'token' => $request->bearerToken(),
+                'header_auth' => $request->header('Authorization'),
+                'exception' => $e->getMessage()
+            ]);
+
+            return response()->json([
+                'message' => 'Auth user not found',
+            ], 401);
+        }
+
+        \Log::info('[submit] Auth user', [
+            'token' => $request->bearerToken(),
+            'user' => $user,
+        ]);
+
+        $request->validate([
+            'screening_scoring_id' => 'required|uuid|exists:screening_scorings,id',
+            'answers' => 'required|array',
+            'answers.*.question_id' => 'required|uuid|exists:questions,id',
+            'answers.*.selected_option_id' => 'nullable|uuid|exists:options,id',
+            'answers.*.answer_text' => 'nullable|string',
+        ]);
+
+        DB::beginTransaction();
+
+        try {
+            $optionIds = collect($request->answers)
+                ->pluck('selected_option_id')
+                ->filter()
+                ->unique();
+
+            $optionScores = Option::whereIn('id', $optionIds)->get()->keyBy('id');
+
+            $history = UserHistoryScreeningScoring::create([
+                'user_id' => $user->id,
+                'screening_scoring_id' => $request->screening_scoring_id,
+                'sum_score' => 0,
+            ]);
+
+            $total = 0;
+
+            foreach ($request->answers as $ans) {
+                UserAnswerScreeningScoring::create([
+                    'user_id' => $user->id,
+                    'user_history_screening_scoring_id' => $history->id,
+                    'question_id' => $ans['question_id'],
+                    'selected_option_id' => $ans['selected_option_id'] ?? null,
+                    'answer_text' => $ans['answer_text'] ?? null,
+                    'answered_at' => now(),
+                ]);
+
+                if (!empty($ans['selected_option_id'])) {
+                    $option = $optionScores->get($ans['selected_option_id']);
+                    if ($option) {
+                        $total += $option->score;
+                    }
+                }
+            }
+
+            $history->update(['sum_score' => $total]);
+
+            DB::commit();
+
+            return response()->json([
+                'message' => 'Screening scoring submitted',
+                'sum_score' => $total,
+                'history_id' => $history->id,
+            ]);
+        } catch (\Throwable $e) {
+            DB::rollBack();
+
+            return response()->json([
+                'message' => 'Gagal submit',
+                'error' => $e->getMessage()
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/UserHistoryScreeningScoringController.php
+++ b/app/Http/Controllers/UserHistoryScreeningScoringController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\UserHistoryScreeningScoring;
+
+class UserHistoryScreeningScoringController extends Controller
+{
+    public function index()
+    {
+        $user = auth()->user();
+
+        $histories = UserHistoryScreeningScoring::with('screening')
+            ->where('user_id', $user->id)
+            ->latest()
+            ->get();
+
+        return response()->json([
+            'meta' => ['status' => 'success'],
+            'data' => $histories
+        ]);
+    }
+
+    public function show($id)
+    {
+        $history = UserHistoryScreeningScoring::with([
+            'screening',
+            'answers.question.options',
+            'answers.selectedOption',
+            'user'
+        ])->findOrFail($id);
+
+        return response()->json([
+            'meta' => ['status' => 'success'],
+            'data' => [
+                'id' => $history->id,
+                'sum_score' => $history->sum_score,
+                'user' => $history->user->only(['id', 'name']),
+                'screening' => $history->screening->only(['id', 'name', 'type']),
+                'answers' => $history->answers->map(function ($ans) {
+                    return [
+                        'question' => $ans->question->question_text,
+                        'options' => $ans->question->options->map(fn($o) => [
+                            'id' => $o->id,
+                            'text' => $o->option_text,
+                            'score' => $o->score
+                        ]),
+                        'selected_option' => $ans->selectedOption ? [
+                            'id' => $ans->selectedOption->id,
+                            'text' => $ans->selectedOption->option_text,
+                            'score' => $ans->selectedOption->score,
+                        ] : null,
+                        'answer_text' => $ans->answer_text,
+                    ];
+                })
+            ]
+        ]);
+    }
+
+    public function getAllHistory()
+    {
+        $histories = UserHistoryScreeningScoring::with(['screening', 'user'])
+            ->latest()->get();
+
+        return response()->json([
+            'meta' => ['status' => 'success'],
+            'data' => $histories
+        ]);
+    }
+
+    public function getByScreeningId($screeningScoringId)
+    {
+        $histories = UserHistoryScreeningScoring::with(['user', 'screening'])
+            ->where('screening_scoring_id', $screeningScoringId)
+            ->latest()
+            ->get();
+
+        if ($histories->isEmpty()) {
+            return response()->json([
+                'meta' => ['status' => 'error', 'message' => 'No history found'],
+                'data' => [],
+            ], 404);
+        }
+
+        return response()->json([
+            'meta' => ['status' => 'success'],
+            'data' => $histories
+        ]);
+    }
+
+    public function destroy($id)
+    {
+        $history = UserHistoryScreeningScoring::find($id);
+
+        if (!$history) {
+            return response()->json(['message' => 'History not found'], 404);
+        }
+
+        $history->delete();
+
+        return response()->json(['message' => 'History deleted']);
+    }
+
+}

--- a/app/Models/ScreeningScoring.php
+++ b/app/Models/ScreeningScoring.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Str;
+
+class ScreeningScoring extends Model
+{
+    use HasFactory;
+
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'question_set_id',
+        'name',
+        'type',
+    ];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (empty($model->id)) {
+                $model->id = (string) Str::uuid();
+            }
+        });
+    }
+
+    public function questionSet()
+    {
+        return $this->belongsTo(QuestionSet::class);
+    }
+
+    public function histories()
+    {
+        return $this->hasMany(UserHistoryScreeningScoring::class, 'screening_scoring_id');
+    }
+}

--- a/app/Models/UserAnswerScreeningScoring.php
+++ b/app/Models/UserAnswerScreeningScoring.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Str;
+
+class UserAnswerScreeningScoring extends Model
+{
+    use HasFactory;
+
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'user_id',
+        'user_history_screening_scoring_id',
+        'question_id',
+        'selected_option_id',
+        'answer_text',
+        'answered_at',
+    ];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (empty($model->id)) {
+                $model->id = (string) Str::uuid();
+            }
+        });
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function history()
+    {
+        return $this->belongsTo(UserHistoryScreeningScoring::class, 'user_history_screening_scoring_id');
+    }
+
+    public function question()
+    {
+        return $this->belongsTo(Question::class);
+    }
+
+    public function selectedOption()
+    {
+        return $this->belongsTo(Option::class, 'selected_option_id');
+    }
+}

--- a/app/Models/UserHistoryScreeningScoring.php
+++ b/app/Models/UserHistoryScreeningScoring.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Str;
+
+class UserHistoryScreeningScoring extends Model
+{
+    use HasFactory;
+
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'user_id',
+        'screening_scoring_id',
+        'sum_score',
+    ];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (empty($model->id)) {
+                $model->id = (string) Str::uuid();
+            }
+        });
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function screening()
+    {
+        return $this->belongsTo(ScreeningScoring::class, 'screening_scoring_id');
+    }
+
+    public function answers()
+    {
+        return $this->hasMany(UserAnswerScreeningScoring::class, 'user_history_screening_scoring_id');
+    }
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,4 +1,4 @@
-<?php
+    <?php
 
 return [
 

--- a/database/migrations/2025_07_09_183359_create_screening_scorings_table.php
+++ b/database/migrations/2025_07_09_183359_create_screening_scorings_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('screening_scorings', function (Blueprint $table) {
+            $table->uuid('id')->primary(); // ID tipe UUID
+            $table->foreignUuid('question_set_id') // relasi ke bank soal
+                ->constrained()
+                ->onDelete('cascade');
+            $table->string('name'); // nama screening scoring
+            $table->enum('type', ['HT', 'DM']); // tipe hanya HT atau DM
+            $table->timestamps(); // created_at dan updated_at
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('screening_scorings');
+    }
+};

--- a/database/migrations/2025_07_09_183439_create_user_history_screening_scorings_table.php
+++ b/database/migrations/2025_07_09_183439_create_user_history_screening_scorings_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_history_screening_scorings', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            // Relasi ke user
+            $table->foreignUuid('user_id')->constrained()->onDelete('cascade');
+
+            // Relasi ke screening scoring
+            $table->foreignUuid('screening_scoring_id')->constrained()->onDelete('cascade');
+
+            // Nilai akhir dari hasil pengerjaan
+            $table->integer('sum_score')->default(0);
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_history_screening_scorings');
+    }
+};

--- a/database/migrations/2025_07_09_183530_create_user_answer_screening_scorings_table.php
+++ b/database/migrations/2025_07_09_183530_create_user_answer_screening_scorings_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('user_answer_screening_scorings', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            // Relasi ke user
+            $table->foreignUuid('user_id')->constrained()->onDelete('cascade');
+
+            // Relasi ke riwayat screening user (nama constraint manual agar tidak terlalu panjang)
+            $table->uuid('user_history_screening_scoring_id');
+            $table->foreign('user_history_screening_scoring_id', 'fk_uasc_uhss')
+                ->references('id')
+                ->on('user_history_screening_scorings')
+                ->onDelete('cascade');
+
+            // Relasi ke soal
+            $table->foreignUuid('question_id')->constrained()->onDelete('cascade');
+
+            // Relasi ke opsi jawaban (bisa nullable jika isian bebas)
+            $table->foreignUuid('selected_option_id')->nullable();
+            $table->foreign('selected_option_id', 'fk_uasc_opt')
+                ->references('id')
+                ->on('options')
+                ->onDelete('cascade');
+
+            // Jawaban isian bebas (jika bukan pilihan ganda)
+            $table->text('answer_text')->nullable();
+
+            // Waktu dijawab
+            $table->timestamp('answered_at')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_answer_screening_scorings');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,8 @@ class DatabaseSeeder extends Seeder
         SubModuleSeeder::class,
         DiscussionSeeder::class,
         UsersTableSeeder::class,
+
+        ScreeningScoringSeeder::class,
     ]);
 }
 }

--- a/database/seeders/ScreeningScoringSeeder.php
+++ b/database/seeders/ScreeningScoringSeeder.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\QuestionSet;
+use App\Models\Question;
+use App\Models\Option;
+use App\Models\ScreeningScoring;
+use Illuminate\Support\Str;
+
+class ScreeningScoringSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // Buat Question Set (bank soal)
+        $questionSet = QuestionSet::create([
+            'id' => Str::uuid(),
+            'name' => 'Bank Soal Skoring Hipertensi',
+        ]);
+
+        // Buat pertanyaan dan opsi berskoring
+        $question = Question::create([
+            'id' => Str::uuid(),
+            'question_set_id' => $questionSet->id,
+            'question_text' => 'Seberapa sering Anda merasa pusing?',
+        ]);
+
+        Option::insert([
+            [
+                'id' => Str::uuid(),
+                'question_id' => $question->id,
+                'option_text' => 'Tidak pernah',
+                'score' => 0,
+                'option_index' => 1
+            ],
+            [
+                'id' => Str::uuid(),
+                'question_id' => $question->id,
+                'option_text' => 'Kadang-kadang',
+                'score' => 1,
+                'option_index' => 2
+            ],
+            [
+                'id' => Str::uuid(),
+                'question_id' => $question->id,
+                'option_text' => 'Sering',
+                'score' => 2,
+                'option_index' => 3
+            ],
+        ]);
+
+        // Buat screening scoring
+        ScreeningScoring::create([
+            'id' => Str::uuid(),
+            'question_set_id' => $questionSet->id,
+            'name' => 'Screening Skoring Hipertensi Dummy',
+            'type' => 'HT'
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,6 +23,9 @@ use App\Http\Controllers\UserController;
 use App\Http\Controllers\UserHistoryPostTestController;
 use App\Http\Controllers\UserHistoryPreTestController;
 use App\Http\Controllers\UserHistoryScreeningController;
+use App\Http\Controllers\ScreeningScoringController;
+use App\Http\Controllers\UserAnswerScreeningScoringController;
+use App\Http\Controllers\UserHistoryScreeningScoringController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -107,6 +110,12 @@ Route::middleware('auth:api')->group(function () {
 
     // Submit screening routes
     Route::post('/screening/submit', [UserAnswerScreeningController::class, 'submit']);
+
+    Route::get('/screening-scorings', [ScreeningScoringController::class, 'index']);
+    Route::get('/screening-scorings/{id}', [ScreeningScoringController::class, 'show']);
+    Route::post('/screening-scorings/submit', [UserAnswerScreeningScoringController::class, 'submit']);
+    Route::get('/screening-scorings/history', [UserHistoryScreeningScoringController::class, 'index']);
+    Route::get('/screening-scorings/history/{id}', [UserHistoryScreeningScoringController::class, 'show']);
 
     // History pre test public routes (read access)
     Route::get('/pre-test/history', [UserHistoryPreTestController::class, 'index']);
@@ -194,6 +203,10 @@ Route::middleware('auth:api')->group(function () {
         Route::put('/screening/{id}', [ScreeningController::class, 'update']);
         Route::delete('/screening/{id}', [ScreeningController::class, 'destroy']);
 
+        Route::post('/screening-scorings', [ScreeningScoringController::class, 'store']);
+        Route::put('/screening-scorings/{id}', [ScreeningScoringController::class, 'update']);
+        Route::delete('/screening-scorings/{id}', [ScreeningScoringController::class, 'destroy']);
+
         // Pre Test admin routes
         Route::post('/pre-test', [PreTestController::class, 'store']);
         Route::put('/pre-test/{id}', [PreTestController::class, 'update']);
@@ -231,6 +244,9 @@ Route::middleware('auth:api')->group(function () {
             Route::get('/post-test', [UserHistoryPostTestController::class, 'getAllHistory']);
             Route::get('/post-test/users/{postTestId}', [UserHistoryPostTestController::class, 'getByPostTestId']);
             Route::delete('/post-test/users/history/{id}', [UserHistoryPostTestController::class, 'destroy']);
+            Route::get('/screening-scorings', [UserHistoryScreeningScoringController::class, 'getAllHistory']);
+            Route::get('/screening-scorings/users/{screeningScoringId}', [UserHistoryScreeningScoringController::class, 'getByScreeningId']);
+            Route::delete('/screening-scorings/users/history/{id}', [UserHistoryScreeningScoringController::class, 'destroy']);
         });
 
         // Users admin routes


### PR DESCRIPTION
feat(api): finalize screening scoring endpoints for patient and admin

- Added patient routes:
  - GET /screening-scorings
  - GET /screening-scorings/{id}
  - POST /screening-scorings/submit
  - GET /screening-scorings/history
  - GET /screening-scorings/history/{id}

- Added admin routes for CRUD screening:
  - POST /screening-scorings
  - PUT /screening-scorings/{id}
  - DELETE /screening-scorings/{id}

- Added admin routes for user history management:
  - GET /history/screening-scorings
  - GET /history/screening-scorings/users/{screeningScoringId}
  - DELETE /history/screening-scorings/users/history/{id}
